### PR TITLE
Refactor broadcasts

### DIFF
--- a/pkg/game/player.go
+++ b/pkg/game/player.go
@@ -56,18 +56,15 @@ func AddPlayerToLobby(clientID string, clientName string, lobbyID string, conn *
 
 	lobby.NumPlayers = len(lobby.PlayerMap)
 
-	hub.Broadcast <- models.ResponseBase{
+	hub.BroadcastMessage(models.ResponseBase{
 		Status: "OK", Type: "JOINED_LOBBY",
 		Payload: models.ResponsePayload{
 			User:  client.ID,
 			Lobby: lobby,
 		},
-	}
+	})
 
-	// TODO: this is a workaround to ensure rejoin is sent after broadcast
-	time.Sleep(200 * time.Millisecond)
-
-	// send data to resume mid round
+	// if round is active send current location to allow client to resume playing
 	if lobby.Active && lobby.RountTimer.Timer != nil {
 		message := models.ResponsePayload{
 			Loc:           &lobby.CurrentLoc[lobby.CurrentRound-1],


### PR DESCRIPTION
When using channels for broadcast it's possible for a later direct send message to be sent before the broadcast one.
This adds a new `BroadcastMessage` function that blocks until the message has been queued for all clients. Using the broadcast channel directly is still possible (internally it uses `BroadcastMessage`) but doing so in non blocking and does not ensure client queue order.